### PR TITLE
Fix Maximum sold decimal issue

### DIFF
--- a/src/pages/Swap/useGetSwapInfo/formatToSwap.ts
+++ b/src/pages/Swap/useGetSwapInfo/formatToSwap.ts
@@ -51,7 +51,7 @@ const formatToSwap = ({ trade, input }: FormatToSwapInput): FormatToSwapOutput =
     }),
     maximumFromTokenAmountSoldWei: convertTokensToWei({
       value: new BigNumber(trade.maximumAmountIn(slippagePercent).toFixed()),
-      token: input.toToken,
+      token: input.fromToken,
     }),
     toTokenAmountReceivedWei: convertTokensToWei({
       value: new BigNumber(trade.outputAmount.toFixed()),


### PR DESCRIPTION
## Jira ticket(s)

ONYX-Fix-Maximum-Sold-Decimals

## Changes

- Changed toToken to fromToken in formatToSwap.ts when calculating maximumFromTokenAmountSoldWei.
